### PR TITLE
Remove dynamic iskeyword

### DIFF
--- a/README
+++ b/README
@@ -5,10 +5,12 @@ This plugin configures Vim to be a little more efficient at editing XQuery...!
 It also sets up Exuberant Ctags for XQuery, since it's not one of the supported languages.
 
 ftplugin/xquery.vim:
-    -Makes keys like gd and<C-]> and i_CTRL-p work better when editing XQuery files by temporarily adding the hyphen - to the 'iskeyword' option
-    -Sets options useful when editing XQuery (like 'set comments')
-    -Sets a few variables to make matchit.vim and taglist.vim work better with XQuery
-    -Comment regions out via surround.vim by visually selecting an area, then pressing Sc
+    - Makes keys like gd and<C-]> and i_CTRL-p work better when editing XQuery files by adding the hyphen - to the 'iskeyword' option
+      - NB: this makes navigation with w etc. skip over whole tokens.  To navigate by dashes, use https://github.com/bkad/CamelCaseMotion
+        and navigate with <Leader>w instead.  (e.g. ,w by default)
+    - Sets options useful when editing XQuery (like 'set comments')
+    - Sets a few variables to make matchit.vim and taglist.vim work better with XQuery
+    - Comment regions out via surround.vim by visually selecting an area, then pressing Sc
 
 xquerycomplete.vim:
     -Completes W3C XQuery 'fn' functions, types and keywords.
@@ -57,6 +59,10 @@ indent/xquery.vim:
          
 
 __install details__
+
+Just use your favourite package manager (Vundle etc.)  You'll have to additionally do steps 4-5 below if you want Ctags support.
+
+OR
 
   1.  Copy ftplugin/xquery.vim to $HOME/.vim/ftplugin or $HOME/vimfiles/ftplugin or $VIM/vimfiles/ftplugin (and set 'filetype plugin on')
   2.  Copy autoload/xquerycomplete.vim to $HOME/.vim/autoload or $HOME/vimfiles/autoload or $VIM/vimfiles/autoload

--- a/ftplugin/xquery.vim
+++ b/ftplugin/xquery.vim
@@ -4,10 +4,11 @@
 " Last Change:  2011 Jun 2
 "
 " Notes: 
-"    -Makes keys like gd and <C-]> work better when editing XQuery files 
-"     by temporarily adding the hyphen - to the 'iskeyword' variable
-"     (one could add it to 'iskeyword' permanently... but that makes the 
-"     basic movement keys move a bit too far)
+"    -Removes the original plugin's behaviour with adding/removing 'iskeyword'
+"    as I found this overly fragile (e.g. breaks any function that isn't
+"    explicitly overridden.)
+"    to address the original reason for this behaviour, you may wish to
+"    install https://github.com/bkad/CamelCaseMotion as well
 "
 "    -Sets options that are useful when editing XQuery (like 'set comments')
 
@@ -20,133 +21,7 @@
 "
 
 
-" Only do this when not done yet for this buffer
-if exists("b:did_ftplugin")
-"  finish
-   delfunction xqueryft:XQueryTag
-   delfunction xqueryft:XQueryGotoDeclaration
-   delfunction xqueryft:Star
-   delfunction xqueryft:BracketI
-endif
-let b:did_ftplugin = 1
-
-" http://markmail.org/message/5vfzrb7ojvds5drx
-autocmd InsertEnter *.xqy,*.xql,*.xqe,*.xq set iskeyword+=-
-autocmd InsertLeave *.xqy,*.xql,*.xqe,*.xq set iskeyword-=-
-"imap <C-c> <ESC>   "Because <C-c> dosent trigger InsertLeave (see help) 
-inoremap <C-c> <C-c>:set isk-=-<cr>
-
-"12/1/2010  Because XQueryTag() does not trigger InsertLeave when you come back
-"           to the buffer you made the jump in via i_Ctrl-T or i_Ctrl-O or something
-autocmd BufEnter *.xqy,*.xql,*.xqe,*.xq set iskeyword-=-   
-
-if !exists("*xqueryft:XQueryTag")
-    function! xqueryft:XQueryTag(is_tjump)
-     
-      set iskeyword+=-
-
-      let l:is_xqVariable = synIDattr(synID(line('.'), col('.'), 0), "name") == 'xqVariable'
-
-      let l:word_at_cursor = expand("<cword>")
-      let l:WORD_at_cursor = expand("<cWORD>")
-
-      "remove the namespace: part from word_at_cursor
-      
-      let l:dollar_index = match(l:word_at_cursor, '$')
-      let l:colon_index  = match(l:word_at_cursor, ':')
-      let l:word_at_cursor_without_namespace = strpart(word_at_cursor, l:colon_index)
-
-      " if l:word_at_cursor appears to be a function namespace, set it to be
-      " the function name so we can tagjump to it
-      "
-      if matchstr(l:WORD_at_cursor, l:word_at_cursor.':') != ""
-
-        let l:orig_col = getpos('.')[2]
-        call search(':')
-        let l:word_at_cursor = expand("<cword>")
-        " go back to where we were
-        call cursor(line('.'), l:orig_col)
-      endif
-    
-      " finally... do the tag jump 
-
-      let l:tagtojumpto = (colon_index != -1) ? l:word_at_cursor_without_namespace :  l:word_at_cursor
-
-      exec (a:is_tjump ? "tjump " : "tag ") . l:tagtojumpto
-
-      set iskeyword-=-
-    endfunction
-endif
-
-"  :h gd     
-"  :h searchdecl()     searchdecl(expand("<cword>"), 0, 0)
-"
-if !exists("*xqueryft:XQueryGotoDeclaration")
-    function! xqueryft:XQueryGotoDeclaration(is_goto_global)
-      set iskeyword+=- | let @/='\<'.expand('<cword>').'\>' | set iskeyword-=- 
-
-      if a:is_goto_global
-        call searchdecl(@/, 1, 0)
-      else
-        call searchdecl(@/, 0, 0)
-      endif
-
-      "execute "match Search /" . @/ . "/"
-      normal n
-      normal N
-    endfunction 
-endif
-
-
-if !exists("*xqueryft:Star")
-    function! xqueryft:Star(goforward)
-        set iskeyword+=- | let @/='\<'.expand('<cword>').'\>' | set iskeyword-=- 
-        if a:goforward
-            normal! n 
-        else 
-            normal! N
-        endif
-    endfunction
-endif
-
-if !exists("*xqueryft:BracketI")
-
-    function! xqueryft:BracketI(iscapital)
-        set iskeyword+=- 
-
-        " TODO  find function equivalent for [i and [I 
-
-        set iskeyword-=- 
-    endfunction
-endif
-
-
-"  these from :h write-filetype-plugin
-"
-" Add mappings, unless the user didn't want this.
-if !exists("no_plugin_maps") && !exists("no_mail_maps")
-
-    if !hasmapto('xqueryft:XQueryTag')
-        noremap <buffer> <C-]> :call xqueryft:XQueryTag(0)<CR>
-        noremap <buffer> g<C-]> :call xqueryft:XQueryTag(1)<CR>
-    endif
-
-    if !hasmapto('xqueryft:XQueryGotoDeclaration')
-        noremap <buffer> gd :call xqueryft:XQueryGotoDeclaration(0)<CR>
-        noremap <buffer> gD :call xqueryft:XQueryGotoDeclaration(1)<CR> 
-    endif
-
-    if !hasmapto('xqueryft:Star')
-        noremap <buffer> # :call xqueryft:Star(0)<CR>
-        noremap <buffer> * :call xqueryft:Star(1)<CR>
-    endif
-
-"     if !hasmapto('xqueryft:BracketI')
-"         noremap <buffer> [i :call xqueryft:BracketI(0)<CR>
-"         noremap <buffer> [I :call xqueryft:BracketI(1)<CR>
-"     endif
-
-endif
+setlocal iskeyword+=-
 
 " Comment blocks always start with a (: and end with a :)
 " Works for XQDoc style start comments like (:~ too.


### PR DESCRIPTION
(Not sure if you'll approve this PR, as it reverts a chunk of behaviour, but as I found this useful, thought I'd ping just on the off-chance you did too :-)  Thanks for submitting the original plugin in the first place!)

Set iskeyword locally to buffer in filetype.  This allows us to remove
the over-complicated and fragile dynamic rules for adding or removing
"-" from keyword depending on context.

This removes the original author's desire to be able to use `w`
navigation to parts of words.  To reinstate that, simply install
the plugin at https://github.com/bkad/CamelCaseMotion/ and use
`<Leader>w` etc. instead.
